### PR TITLE
Remove legacy version, improve filter

### DIFF
--- a/hdeps/compatibility.py
+++ b/hdeps/compatibility.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Dict, List, Optional, Tuple
 
-from keke import kev, ktrace
+from keke import kev
 
 from packaging.requirements import Requirement
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
@@ -30,7 +30,7 @@ def find_best_compatible_version(
 
     requires_python_cache: Dict[str, bool] = {}
 
-    def requires_python_match(v):
+    def requires_python_match(v: Version) -> bool:
         pv = project.versions[v]
         if not pv.requires_python:
             return True
@@ -80,7 +80,12 @@ def find_best_compatible_version(
         possible.append(already_chosen)
 
     if not possible:
-        raise ValueError(f"{project.name} has no {python_version}-compatible release")
+        if specifier_matched:
+            raise ValueError(
+                f"{project.name} has no {python_version}-compatible release"
+            )
+        else:
+            raise ValueError(f"{project.name} has no release matching {req.specifier}")
 
     # The documentation for SepcifierSet.filter notes that it handles the logic
     # for whether to include prereleases, so we don't need that here.

--- a/hdeps/compatibility.py
+++ b/hdeps/compatibility.py
@@ -6,11 +6,10 @@ from keke import kev
 from packaging.requirements import Requirement
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import Version
-from packaging_legacy.version import parse as parse_version
 
 from .markers import EnvironmentMarkers
 from .projects import Project
-from .types import LooseVersion, VersionCallback
+from .types import VersionCallback
 
 LOG = logging.getLogger(__name__)
 
@@ -19,16 +18,16 @@ def find_best_compatible_version(
     project: Project,
     req: Requirement,
     env_markers: EnvironmentMarkers,
-    already_chosen: Optional[LooseVersion],
+    already_chosen: Optional[Version],
     current_version_callback: VersionCallback,
-) -> LooseVersion:
+) -> Version:
     # Handle requires_python first, so we can produce a better error message
     # when there are no version-compatible candidates (before we even get to
     # req.specifier)
     python_version_str = env_markers.python_full_version
     assert python_version_str is not None
     python_version = Version(python_version_str)
-    possible: List[LooseVersion] = []
+    possible: List[Version] = []
 
     requires_python_cache: Dict[str, bool] = {}
 
@@ -52,9 +51,9 @@ def find_best_compatible_version(
     # here.
     with kev("current_version_callback"):
         cur = current_version_callback(project.name)
-    cur_v: Optional[LooseVersion] = None
+    cur_v: Optional[Version] = None
     if cur:
-        cur_v = parse_version(cur)
+        cur_v = Version(cur)
         # Here be dragons: if we already filtered the current version out for
         # requires_python, then don't bother adding it back in; this is only
         # intended for non-public version reuse.
@@ -80,7 +79,7 @@ def find_best_compatible_version(
     # ( matches_already_chosen: bool,
     #   matches_current_version: bool,
     #   recency_index: int,
-    #   version: LooseVersion )
+    #   version: Version )
     # so that after sorting the last item is the "best" one.
 
     with kev("final sort"):

--- a/hdeps/projects.py
+++ b/hdeps/projects.py
@@ -49,7 +49,6 @@ class Project:
     @classmethod
     def from_pypi_simple_project_page(cls, project_page: ProjectPage) -> Project:
         vers: Dict[Version, List[DistributionPackage]] = defaultdict(list)
-        # TODO sort vers
         for dp in project_page.packages:
             if dp.version is None:
                 LOG.debug("Ignore unset version in %s", dp.filename)
@@ -60,7 +59,9 @@ class Project:
                 LOG.debug("Ignore invalid version %s in %s", dp.version, dp.filename)
         return cls(
             name=CanonicalName(canonicalize_name(project_page.project)),
-            versions={v: ProjectVersion(v, tuple(pkgs)) for v, pkgs in vers.items()},
+            versions={
+                v: ProjectVersion(v, tuple(pkgs)) for v, pkgs in sorted(vers.items())
+            },
         )
 
 

--- a/hdeps/projects.py
+++ b/hdeps/projects.py
@@ -25,7 +25,7 @@ from seekablehttpfile import SeekableHttpFile
 from seekablehttpfile.core import get_range_requests
 
 from .cache import SimpleCache
-from .types import CanonicalName, LooseVersion
+from .types import CanonicalName
 
 LOG = logging.getLogger(__name__)
 
@@ -44,11 +44,11 @@ def first(it: Iterable[T], default: D) -> Union[T, D]:
 @dataclass(frozen=True)
 class Project:
     name: CanonicalName
-    versions: Dict[LooseVersion, ProjectVersion]
+    versions: Dict[Version, ProjectVersion]
 
     @classmethod
     def from_pypi_simple_project_page(cls, project_page: ProjectPage) -> Project:
-        vers: Dict[LooseVersion, List[DistributionPackage]] = defaultdict(list)
+        vers: Dict[Version, List[DistributionPackage]] = defaultdict(list)
         # TODO sort vers
         for dp in project_page.packages:
             if dp.version is None:
@@ -66,7 +66,7 @@ class Project:
 
 @dataclass(frozen=True)
 class ProjectVersion:
-    version: LooseVersion
+    version: Version
     packages: Tuple[DistributionPackage, ...] = field(hash=False)
 
     @property

--- a/hdeps/resolution.py
+++ b/hdeps/resolution.py
@@ -24,7 +24,7 @@ from .markers import EnvironmentMarkers
 from .projects import BasicMetadata, Project, ProjectVersion
 from .requirements import _iter_simple_requirements
 from .session import get_retry_session
-from .types import CanonicalName, Choice, Edge, LooseVersion, VersionCallback
+from .types import CanonicalName, Choice, Edge, VersionCallback
 
 LOG = logging.getLogger(__name__)
 
@@ -116,7 +116,7 @@ class Walker:
         return md
 
     def drain(self) -> None:
-        chosen: Dict[CanonicalName, LooseVersion] = {}
+        chosen: Dict[CanonicalName, Version] = {}
 
         while self.queue:
             (parent, name, req, source) = self.queue.popleft()
@@ -182,7 +182,7 @@ class Walker:
         self,
         choice: Optional[Choice] = None,
         seen: Optional[
-            Set[Tuple[CanonicalName, LooseVersion, Optional[Tuple[str, ...]]]]
+            Set[Tuple[CanonicalName, Version, Optional[Tuple[str, ...]]]]
         ] = None,
     ) -> None:
         if choice is None:
@@ -206,7 +206,7 @@ class Walker:
         self,
         choice: Optional[Choice] = None,
         seen: Optional[
-            Set[Tuple[CanonicalName, LooseVersion, Optional[Tuple[str, ...]]]]
+            Set[Tuple[CanonicalName, Version, Optional[Tuple[str, ...]]]]
         ] = None,
         known_conflicts: Set[CanonicalName] = set(),
         depth: int = 0,

--- a/hdeps/types.py
+++ b/hdeps/types.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Callable, List, NewType, Optional, Tuple, Union
+from typing import Callable, List, NewType, Optional, Tuple
 
 from packaging.markers import Marker
 from packaging.specifiers import SpecifierSet
 from packaging.version import Version
-from packaging_legacy.version import LegacyVersion
 
-LooseVersion = Union[LegacyVersion, Version]
 CanonicalName = NewType("CanonicalName", str)
 VersionCallback = Callable[[CanonicalName], Optional[str]]
 
@@ -16,7 +14,7 @@ VersionCallback = Callable[[CanonicalName], Optional[str]]
 @dataclass
 class Choice:
     project: CanonicalName = field(repr=True)
-    version: LooseVersion = field(repr=True)
+    version: Version = field(repr=True)
     extras: Tuple[str, ...] = field(default_factory=tuple)
     deps: List[Edge] = field(default_factory=list)
     has_sdist: bool = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,6 @@ install_requires =
     seekablehttpfile
     indexurl
     packaging
-    packaging-legacy
     # tpe-prio
 
 [options.extras_require]


### PR DESCRIPTION
I'm reasonably sure this gives the same result, only with much less work.  This work happens in the main thread (blue/green 2nd row) and is noticeable with hot cache or extremely low latency:

Before
![old](https://github.com/hdeps/hdeps/assets/49834/f2bcd227-f1ce-4412-8f20-babb883968e5)
After
![new](https://github.com/hdeps/hdeps/assets/49834/5765b471-94a7-4e78-b6b3-b8e26ed982cd)