### PR TITLE
Suggest

### DIFF
--- a/hdeps/cli.py
+++ b/hdeps/cli.py
@@ -196,11 +196,14 @@ def main(
                 f"Found conflict: {project} {sorted([str(x) for x in versions])}"
             )
             for version in versions:
-                LOG.debug(f"Trying to pin {project}=={version}")
-                req = Requirement(f"{project}=={version}")
-                walker.clear()
-                walker.feed(req)
-                solve()
+                with keke.kev("pin_attempt", project=project, version=version):
+                    LOG.info("Trying to pin %s==%s", project, version)
+                    req = Requirement(f"{project}=={version}")
+                    walker.clear()
+                    # Add the pin as first requirement to see if it can be used
+                    # by all subsequent dependencies.
+                    walker.feed(req)
+                    solve()
                 if project not in walker.known_conflicts:
                     resolutions.append(req)
                     break

--- a/hdeps/cli.py
+++ b/hdeps/cli.py
@@ -172,7 +172,7 @@ def main(
         color=ctx.color,
     )
 
-    def solve():
+    def solve() -> None:
         for dep in deps:
             walker.feed(Requirement(dep))
         for req in requirements_file:

--- a/hdeps/cli.py
+++ b/hdeps/cli.py
@@ -192,7 +192,9 @@ def main(
     if walker.known_conflicts:
         resolutions: List[Requirement] = []
         for project, versions in walker.known_conflicts.copy().items():
-            click.echo(f"Found conflict: {project} {sorted([str(x) for x in versions])}")
+            click.echo(
+                f"Found conflict: {project} {sorted([str(x) for x in versions])}"
+            )
             for version in versions:
                 LOG.debug(f"Trying to pin {project}=={version}")
                 req = Requirement(f"{project}=={version}")
@@ -212,7 +214,9 @@ def main(
         if unresolved:
             click.echo("Failed to resolve following conflicts:")
             for conflict in unresolved:
-                click.echo(f"{conflict} {sorted([str(x) for x in walker.known_conflicts[conflict]])}")
+                click.echo(
+                    f"{conflict} {sorted([str(x) for x in walker.known_conflicts[conflict]])}"
+                )
     else:
         click.echo("No conflicts found.")
 

--- a/hdeps/cli.py
+++ b/hdeps/cli.py
@@ -192,7 +192,7 @@ def main(
     if walker.known_conflicts:
         resolutions: List[Requirement] = []
         for project, versions in walker.known_conflicts.copy().items():
-            click.echo(f"Found conflict: {project} {versions}")
+            click.echo(f"Found conflict: {project} {sorted([str(x) for x in versions])}")
             for version in versions:
                 LOG.debug(f"Trying to pin {project}=={version}")
                 req = Requirement(f"{project}=={version}")
@@ -212,7 +212,7 @@ def main(
         if unresolved:
             click.echo("Failed to resolve following conflicts:")
             for conflict in unresolved:
-                click.echo(f"{conflict} {walker.known_conflicts[conflict]}")
+                click.echo(f"{conflict} {sorted([str(x) for x in walker.known_conflicts[conflict]])}")
     else:
         click.echo("No conflicts found.")
 

--- a/hdeps/cli.py
+++ b/hdeps/cli.py
@@ -213,7 +213,7 @@ def main(
         unresolved = walker.known_conflicts.keys() - {x.name for x in resolutions}
         if unresolved:
             click.echo("Failed to resolve following conflicts:")
-            for conflict in unresolved:
+            for conflict in sorted(unresolved):
                 click.echo(
                     f"{conflict} {sorted([str(x) for x in walker.known_conflicts[conflict]])}"
                 )

--- a/hdeps/resolution.py
+++ b/hdeps/resolution.py
@@ -278,7 +278,7 @@ class Walker:
         seen: Optional[
             Set[Tuple[CanonicalName, Version, Optional[Tuple[str, ...]]]]
         ] = None,
-        known_conflicts: Dict[CanonicalName, Set[ProjectVersion]] = defaultdict(set),
+        known_conflicts: Dict[CanonicalName, Set[Version]] = defaultdict(set),
         depth: int = 0,
     ) -> None:
         prefix = ". " * depth

--- a/hdeps/resolution.py
+++ b/hdeps/resolution.py
@@ -66,9 +66,13 @@ class Walker:
             Tuple[Choice, CanonicalName, Requirement, str, Set[ChoiceKeyType]]
         ] = deque()
         self.current_version_callback = current_version_callback
-        self.known_conflicts: Dict[CanonicalName, Set[ProjectVersion]] = defaultdict(
+        self.known_conflicts: Dict[CanonicalName, Set[Version]] = defaultdict(
             set
         )
+
+    def clear(self) -> None:
+        self.root = Choice(CanonicalName("-"), Version("0"))
+        self.known_conflicts.clear()
 
     def feed_file(self, req_file: Path) -> None:
         for req in _iter_simple_requirements(req_file):
@@ -166,11 +170,11 @@ class Walker:
             )
             parent.deps.append(edge)
             if choice.key() in parent_keys:
-                LOG.warning("Avoid circular dep processing %s", name)
+                LOG.info("Avoid circular dep processing %s", name)
                 continue
 
             if cur and cur != version:
-                LOG.warning("Multiple versions for %s: %s and %s", name, cur, version)
+                LOG.info("Multiple versions for %s: %s and %s", name, cur, version)
                 self.known_conflicts[name].update([cur, version])
             chosen[name] = version
 

--- a/hdeps/resolution.py
+++ b/hdeps/resolution.py
@@ -66,9 +66,7 @@ class Walker:
             Tuple[Choice, CanonicalName, Requirement, str, Set[ChoiceKeyType]]
         ] = deque()
         self.current_version_callback = current_version_callback
-        self.known_conflicts: Dict[CanonicalName, Set[Version]] = defaultdict(
-            set
-        )
+        self.known_conflicts: Dict[CanonicalName, Set[Version]] = defaultdict(set)
 
     def clear(self) -> None:
         self.root = Choice(CanonicalName("-"), Version("0"))

--- a/hdeps/tests/scenarios/batman_1.txt
+++ b/hdeps/tests/scenarios/batman_1.txt
@@ -2,3 +2,5 @@
 $ hdeps batman==1
 batman (==1.0) via ==1
 . robin (==1.0) via ==1.0
+========== Summary ==========
+No conflicts found.

--- a/hdeps/tests/scenarios/batman_1_install_order.txt
+++ b/hdeps/tests/scenarios/batman_1_install_order.txt
@@ -2,3 +2,5 @@
 $ hdeps --install-order batman==1
 robin==1.0
 batman==1.0
+========== Summary ==========
+No conflicts found.

--- a/hdeps/tests/scenarios/batman_1_no_reuse.txt
+++ b/hdeps/tests/scenarios/batman_1_no_reuse.txt
@@ -2,9 +2,14 @@
 # The specifier on the second one is also listed as-given (without the .0), but
 #   that's just an implementation detail.
 $ hdeps batman batman==1
-WARNING  hdeps.resolution:<n> Multiple versions for batman: 2.0 and 1.0
-WARNING  hdeps.resolution:<n> Multiple versions for robin: 2.0 and 1.0
 batman (==2.0) via *
 . robin (==2.0) via >1.0
 batman (==1.0) via ==1
 . robin (==1.0) via ==1.0
+========== Summary ==========
+Found conflict: batman {<Version('2.0')>, <Version('1.0')>}
+Found conflict: robin {<Version('2.0')>, <Version('1.0')>}
+Pin these project versions to resolve conflict:
+batman==1.0
+Failed to resolve following conflicts:
+robin {<Version('2.0')>, <Version('1.0')>}

--- a/hdeps/tests/scenarios/batman_1_no_reuse.txt
+++ b/hdeps/tests/scenarios/batman_1_no_reuse.txt
@@ -7,9 +7,9 @@ batman (==2.0) via *
 batman (==1.0) via ==1
 . robin (==1.0) via ==1.0
 ========== Summary ==========
-Found conflict: batman {<Version('2.0')>, <Version('1.0')>}
-Found conflict: robin {<Version('2.0')>, <Version('1.0')>}
+Found conflict: batman ['1.0', '2.0']
+Found conflict: robin ['1.0', '2.0']
 Pin these project versions to resolve conflict:
 batman==1.0
 Failed to resolve following conflicts:
-robin {<Version('2.0')>, <Version('1.0')>}
+robin ['1.0', '2.0']

--- a/hdeps/tests/scenarios/batman_1_reuse.txt
+++ b/hdeps/tests/scenarios/batman_1_reuse.txt
@@ -3,3 +3,5 @@ $ hdeps batman==1 batman
 batman (==1.0) via ==1
 . robin (==1.0) via ==1.0
 batman (==1.0) (already listed) via *
+========== Summary ==========
+No conflicts found.

--- a/hdeps/tests/scenarios/batman_have_dep_nonpublic.txt
+++ b/hdeps/tests/scenarios/batman_have_dep_nonpublic.txt
@@ -2,3 +2,5 @@
 $ hdeps --have robin==1.5 batman
 batman (==2.0) via *
 . robin (==1.5) via >1.0 no whl
+========== Summary ==========
+No conflicts found.

--- a/hdeps/tests/scenarios/batman_have_nonpublic.txt
+++ b/hdeps/tests/scenarios/batman_have_nonpublic.txt
@@ -1,3 +1,5 @@
 # A non-public version (so we won't have deps)
 $ hdeps --have batman==1.5 batman
 batman (==1.5) via * no whl
+========== Summary ==========
+No conflicts found.

--- a/hdeps/tests/scenarios/circular_dependency_sdist.txt
+++ b/hdeps/tests/scenarios/circular_dependency_sdist.txt
@@ -1,5 +1,6 @@
 $ hdeps CircularDependencyA
-WARNING  hdeps.resolution:<n> Avoid circular dep processing circulardependencya
 circulardependencya (==0.0.0) via * no whl
 . circulardependencyb (==0.0.0) via * no whl
 . . circulardependencya (==0.0.0) (already listed) via *
+========== Summary ==========
+No conflicts found.

--- a/hdeps/tests/scenarios/color_conflict.txt
+++ b/hdeps/tests/scenarios/color_conflict.txt
@@ -4,8 +4,8 @@ batman (==1.0) via ==1 [conflict]
 batman (==2.0) via ==2 [conflict]
 . robin (==2.0) via >1.0 [conflict]
 ========== Summary ==========
-Found conflict: batman {<Version('2.0')>, <Version('1.0')>}
-Found conflict: robin {<Version('2.0')>, <Version('1.0')>}
+Found conflict: batman ['1.0', '2.0']
+Found conflict: robin ['1.0', '2.0']
 Failed to resolve following conflicts:
-batman {<Version('2.0')>, <Version('1.0')>}
-robin {<Version('2.0')>, <Version('1.0')>}
+batman ['1.0', '2.0']
+robin ['1.0', '2.0']

--- a/hdeps/tests/scenarios/color_conflict.txt
+++ b/hdeps/tests/scenarios/color_conflict.txt
@@ -1,7 +1,11 @@
 $ hdeps --no-color batman==1 batman==2
-WARNING  hdeps.resolution:<n> Multiple versions for batman: 1.0 and 2.0
-WARNING  hdeps.resolution:<n> Multiple versions for robin: 1.0 and 2.0
 batman (==1.0) via ==1 [conflict]
 . robin (==1.0) via ==1.0 [conflict]
 batman (==2.0) via ==2 [conflict]
 . robin (==2.0) via >1.0 [conflict]
+========== Summary ==========
+Found conflict: batman {<Version('2.0')>, <Version('1.0')>}
+Found conflict: robin {<Version('2.0')>, <Version('1.0')>}
+Failed to resolve following conflicts:
+batman {<Version('2.0')>, <Version('1.0')>}
+robin {<Version('2.0')>, <Version('1.0')>}

--- a/hdeps/tests/scenarios/color_legend.txt
+++ b/hdeps/tests/scenarios/color_legend.txt
@@ -6,3 +6,5 @@ $ hdeps --print-legend --no-color batman
 
 batman (==2.0) via * [no_sdist]
 . robin (==2.0) via >1.0 [no_sdist]
+========== Summary ==========
+No conflicts found.

--- a/hdeps/tests/scenarios/markers-in-feed.txt
+++ b/hdeps/tests/scenarios/markers-in-feed.txt
@@ -1,3 +1,5 @@
 # root deps should obey markers too
 $ hdeps --python-version 3.7 "robin==1 ; python_version < '3.10'" "robin==2 ; python_version >= '3.10'"
 robin (==1.0) ; python_version < "3.10" via ==1
+========== Summary ==========
+No conflicts found.

--- a/hdeps/tests/scenarios/prerelease-dep.txt
+++ b/hdeps/tests/scenarios/prerelease-dep.txt
@@ -1,3 +1,5 @@
 $ hdeps batman>=2.1dev0
 batman (==2.1.dev1234) via >=2.1dev0
 . robin (==2.0) via >1.0
+========== Summary ==========
+No conflicts found.

--- a/hdeps/tests/scenarios/requires-python.txt
+++ b/hdeps/tests/scenarios/requires-python.txt
@@ -2,3 +2,5 @@
 # fixtures all have requires-python for that same major.minor version
 $ hdeps --python-version=3.8 pyver
 pyver (==3.8) via *
+========== Summary ==========
+No conflicts found.


### PR DESCRIPTION
Fixes #23 

```
$ hdeps honesty
honesty (==0.2.1) via *
. aiohttp (==3.9.3) via >=3.6
. . aiosignal (==1.3.1) via >=1.1.2
. . . frozenlist (==1.4.1) via >=1.1.0
. . attrs (==23.2.0) via >=17.3.0
. . frozenlist (==1.4.1) (already listed) via >=1.1.1
. . multidict (==6.0.5) via <7.0,>=4.5
. . yarl (==1.9.4) via <2.0,>=1.0
. . . idna (==3.6) via >=2.0
. . . multidict (==6.0.5) (already listed) via >=4.0
. appdirs (==1.4.4) via >=1.4
. click (==8.1.7) via >=7.0
. infer-license (==0.2.0) via >=0.0.6
========== Summary ==========
No conflicts found.
```

```
$ hdeps metaflow
metaflow (==2.11.4) via *
. requests (==2.31.0) via *
. . charset-normalizer (==3.3.2) via <4,>=2
. . idna (==3.6) via <4,>=2.5
. . urllib3 (==2.2.1) via <3,>=1.21.1
. . certifi (==2024.2.2) via >=2017.4.17
. boto3 (==1.34.55) via *
. . botocore (==1.34.55) via <1.35.0,>=1.34.55
. . . jmespath (==1.0.1) via <2.0.0,>=0.7.1
. . . python-dateutil (==2.9.0.post0) via <3.0.0,>=2.1
. . . . six (==1.16.0) via >=1.5
. . . urllib3 (==2.0.7) ; python_version >= "3.10" via <2.1,>=1.25.4
. . jmespath (==1.0.1) (already listed) via <2.0.0,>=0.7.1
. . s3transfer (==0.10.0) via <0.11.0,>=0.10.0
. . . botocore (==1.34.55) (already listed) via <2.0a.0,>=1.33.2
========== Summary ==========
Found conflict: urllib3 ['2.0.7', '2.2.1']
Pin these project versions to resolve conflict:
urllib3==2.0.7
```