### PR TITLE
Fix a bug in --have handling

### DIFF
--- a/hdeps/tests/scenarios/batman_have_public.txt
+++ b/hdeps/tests/scenarios/batman_have_public.txt
@@ -1,0 +1,7 @@
+# There was a bug in PR #26 when the --have version exists, but is not the most
+# recent.
+$ hdeps batman --have batman==1 --have robin==2
+batman (==1) via *
+. robin (==1.0) via ==1.0
+========== Summary ==========
+No conflicts found.


### PR DESCRIPTION
There was no test coverage for this case before, and I didn't notice this in line coverage because it was an omitted `else: pass`.

Caused by the optimization in #26, the logic here was not correct, and the version not being in `candidates` is actually the common case, so we just check `requires_python` again.