### PR TITLE
Ensure that --have is reasonably formatted.

### DIFF
--- a/hdeps/cli.py
+++ b/hdeps/cli.py
@@ -155,7 +155,9 @@ def main(
 
     have_versions: Dict[CanonicalName, str] = {}
     for h in have:
-        k, _, v = h.partition("==")
+        k, op, v = h.partition("==")
+        if op != "==":
+            raise click.ClickException(f"Invalid format for --have: {h!r}")
         have_versions[CanonicalName(canonicalize_name(k))] = v
 
     walker = Walker(


### PR DESCRIPTION
The common thing that I'm trying to protect against is just one `=` or trying to put a more complex specifier like `<2` here.  This currently allows through `===` and does not validate project names, but it's a start.