### PR TITLE
Only log once when requirements.txt lines get ignored

### DIFF
--- a/hdeps/tests/cli_scenarios.py
+++ b/hdeps/tests/cli_scenarios.py
@@ -2,6 +2,7 @@ import logging
 import os
 import re
 import shlex
+import shutil
 import unittest
 from pathlib import Path
 from typing import List, Optional, Tuple
@@ -79,6 +80,8 @@ class CliScenariosTest(unittest.TestCase):
             runner = CliRunner()
             with runner.isolated_filesystem():
                 del logging.root.handlers[:]
+                if (t := Path(path.parent, path.name + ".testdata")).exists():
+                    shutil.copy(t, os.getcwd())
                 result = runner.invoke(main, command, catch_exceptions=False)
 
             cleaned_output = LOG_LINE_TIMESTAMP_RE.sub("", result.output)

--- a/hdeps/tests/scenarios/requirements_parsing_ignore_logging.txt
+++ b/hdeps/tests/scenarios/requirements_parsing_ignore_logging.txt
@@ -1,0 +1,12 @@
+$ hdeps -r requirements_parsing_ignore_logging.txt.testdata
+WARNING  hdeps.requirements:<n> Non-simple requirements are ignored (this message only prints once)
+batman (==1.0) via ==1
+. robin (==1.0) via ==1.0
+batman (==2.0) via ==2
+. robin (==2.0) via >1.0
+========== Summary ==========
+Found conflict: batman ['1.0', '2.0']
+Found conflict: robin ['1.0', '2.0']
+Failed to resolve following conflicts:
+batman ['1.0', '2.0']
+robin ['1.0', '2.0']

--- a/hdeps/tests/scenarios/requirements_parsing_ignore_logging.txt.testdata
+++ b/hdeps/tests/scenarios/requirements_parsing_ignore_logging.txt.testdata
@@ -1,0 +1,4 @@
+--index-url foo
+--no-binary foo
+batman==1
+batman==2


### PR DESCRIPTION
We used to re-parse the file several times due to suggest mode, which would print "Ignoring" on stdout several times (both above and below the tree).  Cache the parsing, but also simplify the message to just give a heads-up.  The lines themselves can still be shown with `--vmodule hdeps.requirements=0` or above.

With a simple scenario test for ignored requirements too.

Fixes #32