### PR TITLE
Allow specifying a path to source checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,15 @@ This code was originally part of [honesty](https://pypi.org/project/honesty/)
 but is easier to iterate on with pypi-simple as its source.
 
 ```sh
+# For looking up published projects
 $ hdeps requests
-...
 $ hdeps --install-order requests
-...
 $ hdeps --have urllib3==1.999 requests
-...
+
+# For looking up local (potentially modified) projects
+$ hdeps .
+$ hdeps /path/to/checkout
+$ hdeps -r /path/to/requirements.{txt,in}
 ```
 
 # Why isn't it a solver?

--- a/hdeps/checkout.py
+++ b/hdeps/checkout.py
@@ -1,39 +1,16 @@
-import os.path
 from pathlib import Path
 
 from typing import List, Tuple
 
-from metadata_please import (
-    basic_metadata_from_pep621_checkout,
-    basic_metadata_from_setuptools_checkout,
-)
+from metadata_please import basic_metadata_from_source_checkout
 
 from packaging.requirements import Requirement
 
 
 def read_checkout_reqs(path: Path) -> Tuple[str, List[Requirement]]:
-    try:
-        bm = basic_metadata_from_pep621_checkout(path)
-    except OSError:
-        pass
-    else:
-        if bm.reqs:
-            return (
-                os.path.join(path, "pyproject.toml"),
-                [Requirement(req) for req in bm.reqs],
-            )
-
-    try:
-        bm = basic_metadata_from_setuptools_checkout(path)
-    except OSError:
-        pass
-    else:
-        if bm.reqs:
-            return (
-                os.path.join(path, "setup.cfg"),
-                [Requirement(req) for req in bm.reqs],
-            )
-
-    raise ValueError(
-        f"Path {path} does not contain a currently-supported static metadata.  Try specifying -r requirements.txt"
-    )
+    bm = basic_metadata_from_source_checkout(path)
+    if not bm.reqs:
+        raise ValueError(
+            f"Path {path} did not yield any dependencies, and may not not contain a currently-supported static metadata format (or maybe it just has no deps).  Try specifying -r requirements.txt or omitting."
+        )
+    return (str(path), [Requirement(r) for r in bm.reqs])

--- a/hdeps/checkout.py
+++ b/hdeps/checkout.py
@@ -1,0 +1,39 @@
+import os.path
+from pathlib import Path
+
+from typing import List, Tuple
+
+from metadata_please import (
+    basic_metadata_from_pep621_checkout,
+    basic_metadata_from_setuptools_checkout,
+)
+
+from packaging.requirements import Requirement
+
+
+def read_checkout_reqs(path: Path) -> Tuple[str, List[Requirement]]:
+    try:
+        bm = basic_metadata_from_pep621_checkout(path)
+    except OSError:
+        pass
+    else:
+        if bm.reqs:
+            return (
+                os.path.join(path, "pyproject.toml"),
+                [Requirement(req) for req in bm.reqs],
+            )
+
+    try:
+        bm = basic_metadata_from_setuptools_checkout(path)
+    except OSError:
+        pass
+    else:
+        if bm.reqs:
+            return (
+                os.path.join(path, "setup.cfg"),
+                [Requirement(req) for req in bm.reqs],
+            )
+
+    raise ValueError(
+        f"Path {path} does not contain a currently-supported static metadata.  Try specifying -r requirements.txt"
+    )

--- a/hdeps/cli.py
+++ b/hdeps/cli.py
@@ -16,6 +16,7 @@ from pypi_simple import ACCEPT_JSON_PREFERRED, PyPISimple
 from vmodule import vmodule_init
 
 from .cache import NoCache, SimpleCache
+from .checkout import read_checkout_reqs
 from .markers import EnvironmentMarkers
 from .resolution import Walker
 from .session import get_cached_retry_session, get_retry_session
@@ -176,7 +177,11 @@ def main(
 
     def solve() -> None:
         for dep in deps:
-            walker.feed(Requirement(dep))
+            if dep.startswith(".") or "/" in dep:
+                source, checkout_deps = read_checkout_reqs(Path(dep))
+                walker.feed_from(checkout_deps, source)
+            else:
+                walker.feed(Requirement(dep))
         for req in requirements_file:
             walker.feed_file(Path(req))
         walker.drain()

--- a/hdeps/projects.py
+++ b/hdeps/projects.py
@@ -162,6 +162,7 @@ class ProjectVersion:
                     # These two lines come from warehouse itself
                     name, version, _ = best_pkg.filename.split("-", 2)
                     md_bytes = metadata_please.from_wheel(zf, name)
+                    assert md_bytes is not None
                     extracted_metadata_cache.set(best_pkg.url, md_bytes)
                 md = md_bytes.decode("utf-8")
         elif best_pkg.package_type == "sdist":

--- a/hdeps/resolution.py
+++ b/hdeps/resolution.py
@@ -4,7 +4,7 @@ from collections import defaultdict, deque
 from concurrent.futures import Future, ThreadPoolExecutor
 
 from pathlib import Path
-from typing import Any, Dict, Optional, Set, Tuple
+from typing import Any, Dict, Iterable, Optional, Set, Tuple
 
 import click
 
@@ -73,8 +73,11 @@ class Walker:
         self.known_conflicts.clear()
 
     def feed_file(self, req_file: Path) -> None:
-        for req in _iter_simple_requirements(req_file):
-            self.feed(req, str(req_file))
+        self.feed_from(_iter_simple_requirements(req_file), str(req_file))
+
+    def feed_from(self, reqs: Iterable[Requirement], source: str = "arg") -> None:
+        for req in reqs:
+            self.feed(req, source)
 
     def feed(self, req: Requirement, source: str = "arg") -> None:
         name = CanonicalName(canonicalize_name(req.name))

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ install_requires =
     cachecontrol[filecache]
     click
     keke
-    metadata-please
+    metadata-please >= 0.1.0
     pypi-simple
     requests
     seekablehttpfile


### PR DESCRIPTION
Tests will fail until https://github.com/python-packaging/metadata-please/pull/3 is released as 0.1.0

I am not sure if there's a better heuristic for detecting a local checkout, I mostly want to use this with "." but I could imagine other paths too.  I'd like to not use .exists() to determine which ones are paths, any other ideas?