### PR TITLE
Improve error message for bad dep string

### DIFF
--- a/hdeps/projects.py
+++ b/hdeps/projects.py
@@ -206,8 +206,9 @@ class ProjectVersion:
                             reqs.append(Requirement(dep))
                         except InvalidRequirement:
                             LOG.warning(
-                                "Skipping invalid requirement %r",
+                                "Skipping invalid requirement %r from %r",
                                 dep,
+                                best_pkg.filename,
                             )
 
                 if t := msg.get_all("Provides-Extra"):


### PR DESCRIPTION
Previous one didn't tell you what actually had the dep:
```
(.venv) [timhatch:hdeps ]$ hdeps celery==5.1.2
2024-11-06 15:35:27,362 WARNING  hdeps.projects:208 Skipping invalid requirement 'pytz (>dev)'
```
New one does:
```
(.venv) [timhatch:hdeps ]$ hdeps celery==5.1.2
2024-11-06 15:38:24,151 WARNING  hdeps.projects:208 Skipping invalid requirement 'pytz (>dev)' from 'celery-5.1.2-py3-none-any.whl'
```