### PR TITLE
Add --paths-to option to filter tree to paths leading to named projects

### DIFF
--- a/hdeps/cli.py
+++ b/hdeps/cli.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 import threading
 import time
 from pathlib import Path
@@ -95,6 +96,12 @@ def _stats_thread() -> None:
     help="Output a theoretical install order instead of a tree",
 )
 @click.option(
+    "--paths-to",
+    metavar="NAME",
+    multiple=True,
+    help="Only print dependency paths leading to the named project (repeatable)",
+)
+@click.option(
     "--print-legend",
     is_flag=True,
     help="Output the meaning of colors in a header",
@@ -128,6 +135,7 @@ def main(
     no_cache: bool,
     print_legend: bool,
     color: Optional[bool],
+    paths_to: List[str],
 ) -> None:
     if trace:
         ctx.with_resource(keke.TraceOutput(trace))
@@ -193,7 +201,32 @@ def main(
     else:
         if print_legend:
             walker.print_legend()
-        walker.print_tree()
+        if paths_to:
+            cleaned_paths_to = []
+            for n in paths_to:
+                if not re.fullmatch(r"[a-zA-Z0-9_-]+", n):
+                    m = re.match(r"[a-zA-Z0-9_-]+", n)
+                    if not m:
+                        click.echo(
+                            click.style("warning", fg="yellow", bold=True)
+                            + f": --paths-to={n!r} does not start with a valid project name, skipping",
+                            err=True,
+                        )
+                        continue
+                    name_only = m.group()
+                    click.echo(
+                        click.style("warning", fg="yellow", bold=True)
+                        + f": --paths-to={n!r} looks like more than a project name; using {name_only!r}",
+                        err=True,
+                    )
+                    n = name_only
+                cleaned_paths_to.append(n)
+            marked = set().union(
+                *(walker.collect_paths_to(CanonicalName(canonicalize_name(n))) for n in cleaned_paths_to)
+            )
+            walker.print_tree(paths_to=marked)
+        else:
+            walker.print_tree()
 
     click.echo("========== Summary ==========")
     if walker.known_conflicts:

--- a/hdeps/resolution.py
+++ b/hdeps/resolution.py
@@ -231,6 +231,34 @@ class Walker:
                     else:
                         LOG.log(VLOG_2, "    omit")
 
+    def collect_paths_to(self, target: CanonicalName) -> Set[ChoiceKeyType]:
+        """Return the set of choice keys that lie on any path from roots to target."""
+        marked: Set[ChoiceKeyType] = set()
+        seen: Set[ChoiceKeyType] = set()
+        self._mark_paths_to_recursive(target, self.root, seen, marked)
+        return marked
+
+    def _mark_paths_to_recursive(
+        self,
+        target: CanonicalName,
+        choice: Choice,
+        seen: Set[ChoiceKeyType],
+        marked: Set[ChoiceKeyType],
+    ) -> bool:
+        found = choice.project == target
+        for x in choice.deps:
+            key = x.target.key()
+            if key in seen:
+                if key in marked:
+                    found = True
+            else:
+                seen.add(key)
+                if self._mark_paths_to_recursive(target, x.target, seen, marked):
+                    found = True
+        if found and choice is not self.root:
+            marked.add(choice.key())
+        return found
+
     def print_flat(
         self,
         choice: Optional[Choice] = None,
@@ -296,6 +324,7 @@ class Walker:
         ] = None,
         known_conflicts: Dict[CanonicalName, Set[Version]] = defaultdict(set),
         depth: int = 0,
+        paths_to: Optional[Set[ChoiceKeyType]] = None,
     ) -> None:
         prefix = ". " * depth
         if choice is None:
@@ -306,6 +335,8 @@ class Walker:
         assert seen is not None
         # Inorder, but avoid doing duplicate work...
         for x in choice.deps:
+            if paths_to is not None and x.target.key() not in paths_to:
+                continue
             # TODO display whether install or build dep, and whether pin disallows
             # current version, has compatible bdist, no sdist, etc
             key = (x.target.project, x.target.version, x.target.extras)
@@ -355,4 +386,4 @@ class Walker:
                     ),
                 )
                 if x.target.deps:
-                    self.print_tree(x.target, seen, known_conflicts, depth + 1)
+                    self.print_tree(x.target, seen, known_conflicts, depth + 1, paths_to)

--- a/hdeps/tests/scenarios/batman_1_paths_to_batman.txt
+++ b/hdeps/tests/scenarios/batman_1_paths_to_batman.txt
@@ -1,0 +1,6 @@
+# paths-to filters to only nodes on the path; robin is omitted since it is
+# beyond the target
+$ hdeps --paths-to=batman batman==1
+batman (==1.0) via ==1
+========== Summary ==========
+No conflicts found.


### PR DESCRIPTION
Accepts multiple names (repeatable flag); strips and warns on specifier syntax like foo==1.0 so users get a helpful error rather than a silent no-match.