### PR TITLE
Fix python_full_version derivation for Python 3.14 compatibility

### DIFF
--- a/hdeps/markers.py
+++ b/hdeps/markers.py
@@ -19,6 +19,9 @@ class EnvironmentMarkers:
     implementation_name: str = "cpython"
 
     def __post_init__(self) -> None:
+        if self.python_full_version is None and self.python_version is not None:
+            pv = self.python_version
+            self.python_full_version = pv if pv.count(".") >= 2 else pv + ".0"
         if self.sys_platform == "linux":
             if self.python_version and self.python_version[:1] == "2":
                 self.sys_platform = "linux2"


### PR DESCRIPTION
packaging's marker.evaluate() now crashes when python_full_version is None in the environment dict. Derive it from python_version in __post_init__ when not explicitly provided.