### PR TITLE
Add prerelease control: suppress fallback for transitive deps, add --…

### DIFF
--- a/hdeps/cli.py
+++ b/hdeps/cli.py
@@ -105,6 +105,13 @@ def _stats_thread() -> None:
     default=None,
     help="Default is to guess from NO_COLOR or FORCE_COLOR env vars being non-empty",
 )
+@click.option(
+    "--prerelease",
+    type=click.Choice(["allow", "if-necessary", "never"]),
+    default="if-necessary",
+    show_default=True,
+    help="Pre-release version selection strategy.",
+)
 @click.option("--have", help="pkg==ver to assume already installed", multiple=True)
 @click.option("-r", "--requirements-file", multiple=True)
 @click.argument(
@@ -128,6 +135,7 @@ def main(
     no_cache: bool,
     print_legend: bool,
     color: Optional[bool],
+    prerelease: str,
 ) -> None:
     if trace:
         ctx.with_resource(keke.TraceOutput(trace))
@@ -173,6 +181,7 @@ def main(
         current_version_callback=have_versions.get,
         extracted_metadata_cache=extracted_metadata_cache,
         color=ctx.color,
+        prerelease_mode=prerelease,
     )
 
     def solve() -> None:

--- a/hdeps/compatibility.py
+++ b/hdeps/compatibility.py
@@ -49,6 +49,7 @@ def find_best_compatible_version(
     env_markers: EnvironmentMarkers,
     already_chosen: Optional[Version],
     current_version_callback: VersionCallback,
+    allow_pre: Optional[bool] = False,
 ) -> Version:
     # Handle requires_python first, so we can produce a better error message
     # when there are no version-compatible candidates (before we even get to
@@ -61,13 +62,29 @@ def find_best_compatible_version(
         requires_python_match, project, {}, python_version
     )
 
+    # Determine what to pass as `prereleases` to packaging's filter():
+    #   True  → always include pre-releases
+    #   None  → packaging's if-necessary-or-explicit fallback (used for root deps)
+    #   False → only if the specifier explicitly names a pre-release; no fallback
+    #
+    # An already-chosen pre-release always takes priority so it can be reused.
+    pre: Optional[bool]
+    if already_chosen is not None and already_chosen.is_prerelease:
+        pre = True
+    elif allow_pre is True:
+        pre = True
+    elif allow_pre is None:
+        pre = None
+    else:
+        pre = bool(req.specifier.prereleases) or False
+
     possible: List[Version] = []
 
     specifier_matched = False
     with kev("reverse"):
         rev = reversed(project.versions.keys())
     with kev("initial filter"):
-        for version in req.specifier.filter(rev):
+        for version in req.specifier.filter(rev, prereleases=pre):
             specifier_matched = True
             if _requires_python_match(version):
                 # Only keep the first one
@@ -110,9 +127,9 @@ def find_best_compatible_version(
     LOG.log(VLOG_1, "possible for %s: %s", req, possible)
     with kev("filter by specifier"):
         # This should only ever be ~3 items now!
-        possible = list(req.specifier.filter(possible))
+        possible = list(req.specifier.filter(possible, prereleases=pre))
     if not possible:
-        if not list(req.specifier.filter(project.versions.keys())):
+        if not list(req.specifier.filter(project.versions.keys(), prereleases=pre)):
             # Referencing the dragon above, if we had a current version and it was
             # unsuitable, then we still output a generic message.  Note that > does not
             # set the prerelease bit, but >= does.

--- a/hdeps/resolution.py
+++ b/hdeps/resolution.py
@@ -49,6 +49,7 @@ class Walker:
         current_version_callback: VersionCallback = _all_current_versions_unknown,
         extracted_metadata_cache: Optional[SimpleCache] = None,
         color: Optional[bool] = None,
+        prerelease_mode: str = "if-necessary",
     ):
         self.root = Choice(CanonicalName("-"), Version("0"))
         self.pool = ThreadPoolExecutor(max_workers=parallelism)
@@ -67,6 +68,7 @@ class Walker:
         ] = deque()
         self.current_version_callback = current_version_callback
         self.known_conflicts: Dict[CanonicalName, Set[Version]] = defaultdict(set)
+        self.prerelease_mode = prerelease_mode
 
     def clear(self) -> None:
         self.root = Choice(CanonicalName("-"), Version("0"))
@@ -167,12 +169,19 @@ class Walker:
             cur = chosen.get(name)
             with kev("find_best_compatible_version", project_name=name, req=str(req)):
                 try:
+                    if self.prerelease_mode == "allow":
+                        allow_pre: Optional[bool] = True
+                    elif self.prerelease_mode == "never":
+                        allow_pre = False
+                    else:  # if-necessary
+                        allow_pre = None if source != "dep" else False
                     version = find_best_compatible_version(
                         project,
                         req,
                         self.env_markers,
                         cur,
                         self.current_version_callback,
+                        allow_pre=allow_pre,
                     )
                 except NoMatchingRelease:
                     LOG.error("No matching version for %s processing %s", req, name)

--- a/hdeps/tests/fixtures/batman-3.0.dev0-py3-none-any.whl.metadata
+++ b/hdeps/tests/fixtures/batman-3.0.dev0-py3-none-any.whl.metadata
@@ -1,0 +1,2 @@
+Name: batman
+Requires-Dist: robin>1.0

--- a/hdeps/tests/fixtures/batman.html
+++ b/hdeps/tests/fixtures/batman.html
@@ -1,3 +1,4 @@
 <a href="/batman-1.0-py3-none-any.whl" data-core-metadata="sha1=eefea54dd061d4a0c6870ed4315fddadabbf1d81">batman-1.0-py3-none-any.whl</a>
 <a href="/batman-2.0-py3-none-any.whl" data-core-metadata="sha1=9fb327d649db9e4edcbbf1e0a25bf8a3b9c7a260">batman-2.0-py3-none-any.whl</a>
 <a href="/batman-2.1dev1234-py3-none-any.whl" data-core-metadata="sha1=9fb327d649db9e4edcbbf1e0a25bf8a3b9c7a260">batman-2.1dev1234-py3-none-any.whl</a>
+<a href="/batman-3.0.dev0-py3-none-any.whl" data-core-metadata="sha1=9fb327d649db9e4edcbbf1e0a25bf8a3b9c7a260">batman-3.0.dev0-py3-none-any.whl</a>

--- a/hdeps/tests/fixtures/joker-1.0-py3-none-any.whl.metadata
+++ b/hdeps/tests/fixtures/joker-1.0-py3-none-any.whl.metadata
@@ -1,0 +1,2 @@
+Name: joker
+Requires-Dist: batman>=2.5

--- a/hdeps/tests/fixtures/joker.html
+++ b/hdeps/tests/fixtures/joker.html
@@ -1,0 +1,1 @@
+<a href="/joker-1.0-py3-none-any.whl" data-core-metadata="sha1=1117e4f1015e00a19dd6e64e165cee9b01799b3d">joker-1.0-py3-none-any.whl</a>

--- a/hdeps/tests/scenarios/prerelease-dep-not-allowed.txt
+++ b/hdeps/tests/scenarios/prerelease-dep-not-allowed.txt
@@ -1,0 +1,5 @@
+$ hdeps joker
+ERROR    hdeps.resolution:<n> No matching version for batman>=2.5 processing batman
+joker (==1.0) via *
+========== Summary ==========
+No conflicts found.

--- a/hdeps/tests/scenarios/prerelease-flag-allow.txt
+++ b/hdeps/tests/scenarios/prerelease-flag-allow.txt
@@ -1,0 +1,6 @@
+$ hdeps --prerelease=allow joker
+joker (==1.0) via *
+. batman (==3.0.dev0) via >=2.5
+. . robin (==2.0) via >1.0
+========== Summary ==========
+No conflicts found.

--- a/hdeps/tests/scenarios/prerelease-flag-if-necessary.txt
+++ b/hdeps/tests/scenarios/prerelease-flag-if-necessary.txt
@@ -1,0 +1,5 @@
+$ hdeps --prerelease=if-necessary joker
+ERROR    hdeps.resolution:<n> No matching version for batman>=2.5 processing batman
+joker (==1.0) via *
+========== Summary ==========
+No conflicts found.

--- a/hdeps/tests/scenarios/prerelease-flag-never.txt
+++ b/hdeps/tests/scenarios/prerelease-flag-never.txt
@@ -1,0 +1,5 @@
+$ hdeps --prerelease=never joker
+ERROR    hdeps.resolution:<n> No matching version for batman>=2.5 processing batman
+joker (==1.0) via *
+========== Summary ==========
+No conflicts found.

--- a/hdeps/tests/scenarios/prerelease-not-allowed.txt
+++ b/hdeps/tests/scenarios/prerelease-not-allowed.txt
@@ -1,5 +1,5 @@
-$ hdeps batman>=2.1dev0
-batman (==3.0.dev0) via >=2.1dev0
+$ hdeps batman>=2.5
+batman (==3.0.dev0) via >=2.5
 . robin (==2.0) via >1.0
 ========== Summary ==========
 No conflicts found.

--- a/hdeps/tests/scenarios/prerelease-reuse.txt
+++ b/hdeps/tests/scenarios/prerelease-reuse.txt
@@ -1,0 +1,7 @@
+$ hdeps batman>=2.5 joker
+batman (==3.0.dev0) via >=2.5
+. robin (==2.0) via >1.0
+joker (==1.0) via *
+. batman (==3.0.dev0) (already listed) via >=2.5
+========== Summary ==========
+No conflicts found.


### PR DESCRIPTION
…prerelease flag

Pre-releases are now allowed for root (user-supplied) requirements via packaging's if-necessary fallback, but suppressed for transitive dependencies unless the specifier explicitly names a pre-release or a pre-release was already chosen earlier in the resolution (so it can be reused).

Adds --prerelease=allow|if-necessary|never flag (default: if-necessary) to override this behaviour globally.